### PR TITLE
Correctly render commonly found codeblocks

### DIFF
--- a/app/views/gems/show.html.erb
+++ b/app/views/gems/show.html.erb
@@ -2,7 +2,11 @@
 
 <%= render Layout::GemShow.new(gem: @gem, namespaces: @gem.top_level_modules, classes: @gem.classes, class_methods: @gem.class_methods, instance_methods: @gem.instance_methods) do %>
   <div class="grid prose max-w-full">
-    <% markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true) %>
+    <% markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+        autolink: true,
+        tables: true,
+        fenced_code_blocks: true,
+        lax_spacing: true) %>
 
     <%== markdown.render(@gem.readme_content) %>
   </div>


### PR DESCRIPTION
This instructs RedCarpet to detect and render codeblocks, a commonly found markdown element in gem readme files. This is one of the major issues affecting #5.

Before:

<img width="1186" alt="image" src="https://github.com/marcoroth/gem.sh/assets/7969650/8729e94c-6822-4b20-95fa-92fc51d607ab">


After:

<img width="1173" alt="image" src="https://github.com/marcoroth/gem.sh/assets/7969650/12019c4f-46a6-432b-bcac-7f981d58dc05">