### PR TITLE
submit on keyup to have the complete content to search for

### DIFF
--- a/app/views/gems/_search.html.erb
+++ b/app/views/gems/_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(gems_search_path, method: :get, data: { controller: "search", action: "keydown->search#submit", turbo_stream: "true" }) do %>
+<%= form_tag(gems_search_path, method: :get, data: { controller: "search", action: "keyup->search#submit", turbo_stream: "true" }) do %>
   <div class="mt-6" data-action="click->search#open">
     <button type="button" class="group flex h-6 w-6 items-center justify-center md:justify-start h-auto flex-none rounded-lg py-2.5 pl-4 pr-3.5 text-sm border border-gray-200 hover:border-gray-300 w-full">
       <svg aria-hidden="true" viewbox="0 0 20 20" class="h-5 w-5 flex-none fill-gray-400 group-hover:fill-gray-500 group-hover:fill-gray-400">


### PR DESCRIPTION
Hey I noticed a little thing with the search on Gem.sh 
To get the correct result I always need to enter one extra character 

https://github.com/marcoroth/gem.sh/assets/7847244/4cbd64c6-bc12-4565-ab6b-93f091144544

I replaced the keydown by keyup so that when the submit is fired we have the full content. I checked it does work well with content pasting too as well as backspaces.