### PR TITLE
Update to latest parser, use Prism gem instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "httparty", "~> 0.21.0"
 gem "view_component", "~> 3.6"
 
 # Interact with the Ruby syntax tree
-gem "yarp", "~> 0.12"
+gem "prism", "~> 0.13"
 
 # A pure Ruby code highlighter that is compatible with Pygments
 gem "rouge", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    prism (0.13.0)
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
@@ -315,7 +316,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yard (0.9.34)
-    yarp (0.12.0)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -338,6 +338,7 @@ DEPENDENCIES
   jsbundling-rails
   meta-tags
   pg (~> 1.5)
+  prism (~> 0.13)
   puma (~> 6.4)
   rails (~> 7.1.0.beta1)
   rails-html-sanitizer (~> 1.6)
@@ -357,7 +358,6 @@ DEPENDENCIES
   view_component (~> 3.6)
   web-console
   yard (~> 0.9.34)
-  yarp (~> 0.12)
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
YARP got renamed, and has a nice new `Node#type` method that got added, so handling the rename and using the new method.