### PR TITLE
Fix long badges on gem cards

### DIFF
--- a/app/components/ui/badge.rb
+++ b/app/components/ui/badge.rb
@@ -2,7 +2,7 @@
 
 class UI::Badge < ViewComponent::Base
   CLASSES = ClassVariants.build(
-    "rounded-md py-1 px-2 fs-step--2 monospace-font-family font-medium ring-1 ring-inset",
+    "rounded-md py-1 px-2 fs-step--2 monospace-font-family font-medium ring-1 ring-inset self-end",
     variants: {
       color: {
         gray: "bg-gray-50 text-gray-600 ring-gray-600/10",

--- a/app/components/ui/card.html.erb
+++ b/app/components/ui/card.html.erb
@@ -1,16 +1,16 @@
 <div class="p-3 h-full border border-gray-200 hover:bg-gray-50 hover:border-gray-300 rounded-lg flex flex-col justify-between">
   <div class="">
-    <div class="text-sm font-semibold text-gray-800 mb-2 flex justify-between">
+    <div class="text-sm font-semibold text-gray-800 mb-2 flex flex-col">
+      <% if badge? %>
+        <%= badge %>
+      <% end %>
+
       <h4 class="card--title"><%= @title %></h4>
 
       <% if @label %>
         <div class="rounded-md py-1 px-2 fs-step--2 monospace-font-family font-medium ring-1 ring-inset text-gray-700 bg-gray-50 ring-gray-600/10">
           <%= @label %>
         </div>
-      <% end %>
-
-      <% if badge? %>
-        <%= badge %>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Description

Given some gems have very long version names or gem names, and this breaks the UI. Here we can do multiple fixes to the UI in order to avoid this problem but I'm proposing this one, I'm open to work on any other possible fix we can do.

## Screenshots

Before
<img width="1710" alt="CleanShot 2025-03-10 at 00 41 12@2x" src="https://github.com/user-attachments/assets/14e0fb45-e973-4e26-9b9d-a983346b4b92" />

After
<img width="1710" alt="CleanShot 2025-03-10 at 00 39 42@2x" src="https://github.com/user-attachments/assets/6f2eec27-0b2e-447a-b7eb-9b5d5b78484f" />

